### PR TITLE
fixed packages issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,31 @@ Run the app in localhost, with debug enabled so changes are made live:
 ```
 flask run --debug
 ```
+
+
+(On Linux):
+
+Create a virtual environment labelled "auth":
+```
+python3 -m venv auth 
+```
+Activate that virtual environment:
+```
+source auth/bin/activate
+```
+Install the necessary packages within that environment:
+```
+pip install -r requirements.txt
+```
+Name the flask app "project":
+```
+export FLASK_APP="project"
+```
+Run the app in localhost, with debug enabled so changes are made live:
+```
+flask run --debug
+```
+
+
+
 ### HOW TO RUN APPLICATION TESTS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+blinker==1.8.2
+click==8.1.7
+Flask==3.0.3
+Flask-Login==0.6.3
+Flask-SQLAlchemy==3.1.1
+greenlet==3.0.3
+itsdangerous==2.2.0
+Jinja2==3.1.4
+MarkupSafe==2.1.5
+SQLAlchemy==2.0.30
+typing_extensions==4.11.0
+Werkzeug==3.0.3


### PR DESCRIPTION
windows was windowing so i swapped to linux.

Had to rerun environment and install packages (flask, flask-sqlalchemy, flask-login). To make requirements.txt after installing packages, run:
```
pip freeze > requirements.txt
```
If you install anything new, regenerate a new requirements.txt file via the above command.

I also added instructions to run flask app for Linux/Mac in the README.md file
The instructions for running the flask app has changed because of the new package update.

